### PR TITLE
Make javascript Edge-polyfill compatible

### DIFF
--- a/wisvch-footer.html
+++ b/wisvch-footer.html
@@ -40,12 +40,12 @@
     constructor() {
       super();
       const template = doc.getElementById('wisvch-footer');
-
-      const clone = document.importNode(template.content, true);
-      clone.getElementById('year').textContent = new Date().getFullYear();
+      const clone = template.content.cloneNode(true);
 
       const shadow = this.attachShadow({mode: 'open'});
       shadow.appendChild(clone);
+      
+      shadow.getElementById('year').textContent = new Date().getFullYear();
     }
   }
 


### PR DESCRIPTION
Turns out Microsoft is having a hard time following standards, even in their new browser. This PR fixes a `getElementById()` error thrown by former L45.

Credits to @TimvdLippe for providing the actual fix.